### PR TITLE
Fix mirror release workflow indentation

### DIFF
--- a/.github/workflows/mirror-release.yml
+++ b/.github/workflows/mirror-release.yml
@@ -138,15 +138,15 @@ jobs:
 
             # Write body to a file (safer than inline heredoc inside command substitution)
             cat > body.txt <<EOF
-Mirrored upstream release ${tag}
+            Mirrored upstream release ${tag}
 
-Upstream repository: nirs/vmnet-helper
-Upstream tag: ${tag}
-Upstream commit: ${upstream_commit}
+            Upstream repository: nirs/vmnet-helper
+            Upstream tag: ${tag}
+            Upstream commit: ${upstream_commit}
 
-Artifacts in this release are rebuilt from upstream source (see workflow logs for reproducibility details).
-NOTE: The tag in this repo points to a local commit (not the upstream commit); upstream commit recorded above.
-EOF
+            Artifacts in this release are rebuilt from upstream source (see workflow logs for reproducibility details).
+            NOTE: The tag in this repo points to a local commit (not the upstream commit); upstream commit recorded above.
+            EOF
 
             gh release create "${tag}" -t "${tag}" -F body.txt
             echo "Created release ${tag}"


### PR DESCRIPTION
## Summary
- restore full mirror-release workflow from main branch
- fix indentation of heredoc used to compose release descriptions

## Testing
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/mirror-release.yml')"`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8be2d1238832f954a3c2b44410b07