### PR TITLE
Prepare for v0.7.0

### DIFF
--- a/.github/workflows/mirror-upstream-releaes.yml
+++ b/.github/workflows/mirror-upstream-releaes.yml
@@ -3,62 +3,33 @@ on:
   schedule:
     - cron: '0 10 * * *'
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   discover:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     outputs:
       tags: ${{ steps.tags.outputs.tags }}
-      latest_tag: ${{ steps.tags.outputs.latest_tag }}
     steps:
-      - name: Checkout
+      - name: Set up Python
+        uses: actions/setup-python@v5
+      - name: Checkout source
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.MIRROR_TOKEN }}
-      - name: Configure git
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email github-actions[bot]@users.noreply.github.com
-      - name: Determine tags to mirror
+      - name: Find missing tags
         id: tags
         env:
-          GH_TOKEN: ${{ secrets.MIRROR_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          set -euo pipefail
-          git remote add upstream https://github.com/nirs/vmnet-helper.git
-          git fetch upstream --tags
-          upstream_tags=$(git ls-remote --refs --tags upstream | \
-            awk '{print $2}' | sed 's|refs/tags/||' | sort -V)
-          origin_tags=$(git ls-remote --refs --tags origin 2>/dev/null | \
-            awk '{print $2}' | sed 's|refs/tags/||' | sort -V)
-          missing_tags=""
-          for tag in $upstream_tags; do
-            if ! echo "$origin_tags" | grep -q "^$tag$"; then
-              missing_tags="$missing_tags $tag"
-              git fetch upstream "refs/tags/$tag:refs/tags/$tag"
-              git push origin "refs/tags/$tag:refs/tags/$tag"
-              if gh release view "$tag" >/dev/null 2>&1; then
-                echo "Release $tag already exists"
-              else
-                gh release create "$tag" -t "$tag" -n "Mirror of upstream release $tag"
-              fi
-            fi
-          done
-          tags_json=$(printf '%s\n' $missing_tags | \
-            python -c 'import sys,json; print(json.dumps([t for t in sys.stdin.read().split() if t]))')
-          echo "tags=$tags_json" >> $GITHUB_OUTPUT
-          latest_tag=$(printf '%s\n' $upstream_tags | tail -n1)
-          echo "latest tag is $latest_tag"
-          echo "latest_tag=$latest_tag" >> $GITHUB_OUTPUT
-  build_upload_assets:
+          tags=$(./missing-tags)
+          echo "tags=$tags" >> $GITHUB_OUTPUT
+  release:
     needs: discover
     if: needs.discover.outputs.tags != '[]'
     strategy:
       fail-fast: false
       matrix:
         tag: ${{ fromJson(needs.discover.outputs.tags) }}
-        platform: [macos-13, macos-15]
+        platform: [macos-15]
     runs-on: ${{ matrix.platform }}
     permissions:
       contents: write
@@ -75,48 +46,19 @@ jobs:
       - name: Install requirements
         run: brew install meson diffoscope
       - name: Build
-        run: |
-          cd upstream
-          meson setup build
-          meson compile -C build
-          ./archive.sh build
+        working-directory: upstream
+        run: ./build.sh build
       - name: Test reproducibility
+        working-directory: upstream
         run: |
-          cd upstream
-          meson setup repro
-          meson compile -C repro
-          ./archive.sh repro
-          diffoscope build/vmnet-helper-*.tar.gz repro/vmnet-helper-*.tar.gz
-      - name: Upload artifact to release
+          ./build.sh repro
+          diffoscope build/vmnet-helper.tar.gz repro/vmnet-helper.tar.gz
+      - name: Create release
         env:
-          GH_TOKEN: ${{ secrets.MIRROR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # NOTE: We upload the tarball built from upstream code with our
+        # install.sh, configured to install from this repo.
         run: |
-          set -euo pipefail
-
-          repo="minikube-machine/vmnet-helper"
           tag="${{ matrix.tag }}"
-
-          # Find the tarball produced by ./archive.sh build
-          shopt -s nullglob
-          files=(upstream/build/vmnet-helper-*.tar.gz)
-          if (( ${#files[@]} == 0 )); then
-            echo "No tarball found in ./build. Contents are:" >&2
-            ls -lah build || true
-            exit 1
-          fi
-          tarball="${files[0]}"
-
-          # Ensure the release exists
-          if ! gh release view "$tag" --repo "$repo" >/dev/null 2>&1; then
-            gh release create "$tag" --repo "$repo" \
-              -t "$tag" \
-              -n "Mirror of upstream release github.com/nirs/vmnet-helper $tag"
-          fi
-
-          # Upload platform-specific tarball
-          gh release upload --repo "$repo" "$tag" "$tarball" --clobber
-
-          # Upload install.sh once (avoid duplicate uploads across matrix)
-          if [[ "${{ matrix.platform }}" == "macos-15" ]]; then
-            gh release upload --repo "$repo" "$tag" ./install.sh --clobber
-          fi
+          gh release create "$tag" -t "$tag" -n "Mirror of upstream release $tag"
+          gh release upload "$tag" upstream/build/vmnet-helper.tar.gz install.sh

--- a/install.sh
+++ b/install.sh
@@ -1,31 +1,65 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/bash
 
-machine="$(uname -m)"
-archive="vmnet-helper-$machine.tar.gz"
+# -e            Exit if single command, fails
+# -u            Exit when expanding unset variables
+# -o pipefail   Exit if one of the command in a pipeline fails
+set -e -u -o pipefail
 
-# Fail the download if GitHub returns an error page
-curl -fsSLo "$archive" "https://github.com/nirs/vmnet-helper/releases/latest/download/$archive"
+# Interactive installation (default 1)
+# Set to 0 to disable interaction.
+interactive=${VMNET_INTERACTIVE:-1}
 
-# Extract the archive into / (it contains ./opt/vmnet-helper/...)
-sudo tar -xvvmf "$archive" -C / opt/vmnet-helper
-rm -f "$archive"
+# Configur sudo to allow running vmnet-helper without a password (default 1)
+# Set to 0 to skip sudoers configuration.
+configure_sudo=${VMNET_CONFIGURE_SUDO:-1}
 
-install_sudoers() {
-  sudo install -d -m 0755 /etc/sudoers.d
-  sudo install -m 0640 /opt/vmnet-helper/share/doc/vmnet-helper/sudoers.d/vmnet-helper /etc/sudoers.d/
-}
+# GitHub user to install from (default nirs)
+# Modify to install from your fork.
+user=${VMNET_USER:-minikube-machine}
 
-# Non-interactive (CI or no TTY) OR explicit -s flag => install without prompting
-if [[ "${1:-}" == "-s" || -n "${CI:-}" || ! -t 0 ]]; then
-  install_sudoers
+# GitHub repo to install from (default vmnet-helper)
+# Modify to install from your fork if you renamed it.
+repo=${VMNET_REPO:-vmnet-helper}
+
+# Version to install (default latest)
+# Versions before v0.7.0 not supported.
+version=${VMNET_VERSION:-latest}
+
+# Release download URL.
+if [ "$version" = "latest" ]; then
+    release_url="https://github.com/$user/$repo/releases/latest/download/vmnet-helper.tar.gz"
 else
-  yn=""
-  # If read fails (e.g. user hits Ctrl-D), default to Yes
-  read -r -p "Do you want to configure sudoers rule to run without a password? (Y/n) " yn || yn="Y"
-  if [[ -z "$yn" || "$yn" =~ ^[Yy]$ ]]; then
-    install_sudoers
-  fi
+    release_url="https://github.com/$user/$repo/releases/download/$version/vmnet-helper.tar.gz"
 fi
 
-exit 0
+if [ "$interactive" = "1" ]; then
+    echo "Installation requires your password to install vmnet-helper as root"
+    sudo true
+
+    read -p "Configure sudo to run vmnet-helper without a password? (Y/n): " reply </dev/tty
+    case "$reply" in
+        Y|y|"")
+            configure_sudo=1
+            ;;
+        *)
+            configure_sudo=0
+            echo "Please check /opt/vmnet-helper/share/doc/vmnet-helper/sudoers.d/README.md"
+            echo "if you want to configure sudo later."
+            ;;
+    esac
+fi
+
+echo
+echo "Installing vmnet-helper at /opt/vmnet-helper"
+# IMPORTANT: The vmnet-helper executable and the directory where it is installed
+# must be owned by root and may not be modifiable by unprivileged users.
+curl --fail --silent --show-error --location "$release_url" \
+    | sudo tar --extract --verbose --file - --directory / opt/vmnet-helper
+
+if [ $configure_sudo -eq 1 ]; then
+    echo "Installing /etc/sudoers.d/vmnet-helper"
+    sudo install -m 0640 /opt/vmnet-helper/share/doc/vmnet-helper/sudoers.d/vmnet-helper /etc/sudoers.d/
+fi
+
+echo
+echo "✅ vmnet-helper was installed successfully!"

--- a/missing-tags
+++ b/missing-tags
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""
+Print missing tags in local repo.
+"""
+
+import json
+import subprocess
+import sys
+
+UPSTREAM_REPO = "nirs/vmnet-helper"
+
+# Useful when running in a contributor fork.
+if len(sys.argv) > 1:
+    LOCAL_REPO = sys.argv[1]
+else:
+    LOCAL_REPO = "minikube-machine/vmnet-helper"
+
+# These tags used different release artifacts and install process and we cannot
+# mirror them.
+SKIP_TAGS = frozenset(
+    [
+        "v0.6.0",
+        "v0.5.0",
+        "v0.4.0",
+        "v0.3.0",
+        "v0.2.0",
+        "v0.1.0",
+    ]
+)
+
+
+def list_release_tags(repo):
+    cmd = [
+        "gh",
+        "release",
+        "list",
+        "--repo",
+        repo,
+        "--exclude-pre-releases",
+        "--json",
+        "tagName",
+        "--jq",
+        ".[].tagName",
+    ]
+    return subprocess.check_output(cmd).decode().strip().splitlines()
+
+
+upstream_tags = set(list_release_tags(UPSTREAM_REPO))
+local_tags = set(list_release_tags(LOCAL_REPO))
+
+# Missing tags that should be mirrored in local repo.
+missing_tags = sorted(upstream_tags - (local_tags | SKIP_TAGS))
+
+print(json.dumps(missing_tags))

--- a/missing-tags
+++ b/missing-tags
@@ -19,6 +19,10 @@ else:
 # mirror them.
 SKIP_TAGS = frozenset(
     [
+        "v0.7.0-pre4",
+        "v0.7.0-pre3",
+        "v0.7.0-pre2",
+        "v0.7.0-pre1",
         "v0.6.0",
         "v0.5.0",
         "v0.4.0",
@@ -36,7 +40,6 @@ def list_release_tags(repo):
         "list",
         "--repo",
         repo,
-        "--exclude-pre-releases",
         "--json",
         "tagName",
         "--jq",


### PR DESCRIPTION
Import install script from upstream and rewrite the mirror workflow to work with the release structure.

Upstream creates now a universal tarball, so the install script can work only with release v0.7.0 and later. We cannot build now older releases, so anything before v0.7.0 is skipped during the mirror.

We discover the tags to mirror using a helper python script that is much simpler and readable than the previous mess and can run locally.

The release job was updated to use the new build script in upstream (build.sh) and simplified to create and upload the files once without trying to recover from partial releases or files uploaded multiple times. This should not happen now since we run the job only on macos-15.

This PR includes a testing commit to add allow building v0.7.0-pre5. I'll remove it before we merge.

Preview:
- my fork: https://github.com/nirs/minikube-vmnet-helper/releases/tag/v0.7.0-pre5
- upstream: https://github.com/nirs/vmnet-helper/releases/tag/v0.7.0-pre5
