### PR TITLE
Include latest v0.7.0-pre5 for testing

### DIFF
--- a/missing-tags
+++ b/missing-tags
@@ -19,6 +19,10 @@ else:
 # mirror them.
 SKIP_TAGS = frozenset(
     [
+        "v0.7.0-pre4",
+        "v0.7.0-pre3",
+        "v0.7.0-pre2",
+        "v0.7.0-pre1",
         "v0.6.0",
         "v0.5.0",
         "v0.4.0",
@@ -36,7 +40,6 @@ def list_release_tags(repo):
         "list",
         "--repo",
         repo,
-        "--exclude-pre-releases",
         "--json",
         "tagName",
         "--jq",


### PR DESCRIPTION
Release v0.7.0-pre5 can be used for testing. Enable pre-release versions and skip older v0.7.0 pre-releases.