### PR TITLE
tests: Faster and more reliable integration test

### DIFF
--- a/.github/workflows/minikube-integration.yaml
+++ b/.github/workflows/minikube-integration.yaml
@@ -63,7 +63,9 @@ jobs:
         uses: medyagh/setup-minikube@HEAD
         with:
           driver: vfkit
-          start-args: --network vmnet-shared --wait-timeout=20m
+          # Starting full cluster is 2 slow and unreliable in macos-13 runner.
+          start-args: --network vmnet-shared --no-kubernetes --wait-timeout=10m
+          wait: false
 
       - name: Check Proc is up
         if: always()


### PR DESCRIPTION
Using --no-kubernetes is much faster and more reliable, and good enough to validate that vment-helper works.

Examples runs:
- https://github.com/nirs/minikube-vmnet-helper/actions/runs/17896160838/attempts/1: 2m30s
- https://github.com/nirs/minikube-vmnet-helper/actions/runs/17896160838/attempts/2: 3m:22s
- https://github.com/nirs/minikube-vmnet-helper/actions/runs/17896160838/attempts/3: 2m:50s